### PR TITLE
AIDT-1 - Dual Operating System

### DIFF
--- a/papertrail/dep_licenses.md
+++ b/papertrail/dep_licenses.md
@@ -1,81 +1,118 @@
-| Name                    | Version   | License                                            |
-|-------------------------|-----------|----------------------------------------------------|
-| Deprecated              | 1.2.13    | MIT License                                        |
-| Markdown                | 3.3.7     | BSD License                                        |
-| Pillow                  | 9.1.1     | Historical Permission Notice and Disclaimer (HPND) |
-| PyGSP                   | 0.5.1     | BSD License                                        |
-| PyYAML                  | 5.4.1     | MIT License                                        |
-| Werkzeug                | 2.1.2     | BSD License                                        |
-| absl-py                 | 1.1.0     | Apache Software License                            |
-| async-timeout           | 4.0.2     | Apache Software License                            |
-| attrs                   | 21.4.0    | MIT License                                        |
-| cachetools              | 5.2.0     | MIT License                                        |
-| certifi                 | 2022.6.15 | Mozilla Public License 2.0 (MPL 2.0)               |
-| charset-normalizer      | 2.1.0     | MIT License                                        |
-| click                   | 8.1.3     | BSD License                                        |
-| cloudpickle             | 1.6.0     | BSD License                                        |
-| cycler                  | 0.11.0    | BSD License                                        |
-| decorator               | 4.4.2     | BSD License                                        |
-| filelock                | 3.7.1     | Public Domain                                      |
-| flake8                  | 4.0.1     | MIT License                                        |
-| flake8-docstrings       | 1.6.0     | MIT License                                        |
-| gensim                  | 4.2.0     | LGPL-2.1-only                                      |
-| google-auth             | 2.9.0     | Apache Software License                            |
-| google-auth-oauthlib    | 0.4.6     | Apache Software License                            |
-| grpcio                  | 1.47.0    | Apache Software License                            |
-| gym                     | 0.19.0    | UNKNOWN                                            |
-| idna                    | 3.3       | BSD License                                        |
-| imageio                 | 2.9.0     | BSD License                                        |
-| importlib-metadata      | 4.12.0    | Apache Software License                            |
-| iniconfig               | 1.1.1     | MIT License                                        |
-| joblib                  | 1.1.0     | BSD License                                        |
-| karateclub              | 1.3.0     | MIT License                                        |
-| kiwisolver              | 1.4.3     | BSD License                                        |
-| matplotlib              | 3.3.4     | Python Software Foundation License                 |
-| mccabe                  | 0.6.1     | MIT License                                        |
-| msgpack                 | 1.0.4     | Apache Software License                            |
-| networkx                | 2.5.1     | BSD License                                        |
-| numpy                   | 1.19.5    | BSD                                                |
-| oauthlib                | 3.2.0     | BSD License                                        |
-| packaging               | 21.3      | Apache Software License; BSD License               |
-| pandas                  | 1.2.3     | BSD                                                |
-| pluggy                  | 1.0.0     | MIT License                                        |
-| protobuf                | 3.19.4    | 3-Clause BSD License                               |
-| py                      | 1.11.0    | MIT License                                        |
-| pyasn1                  | 0.4.8     | BSD License                                        |
-| pyasn1-modules          | 0.2.8     | BSD License                                        |
-| pycodestyle             | 2.8.0     | MIT License                                        |
-| pydocstyle              | 6.1.1     | MIT License                                        |
-| pyflakes                | 2.4.0     | MIT License                                        |
-| pyparsing               | 3.0.9     | MIT License                                        |
-| pytest                  | 7.1.2     | MIT License                                        |
-| pytest-flake8           | 1.1.1     | BSD License                                        |
-| python-Levenshtein      | 0.12.2    | GNU General Public License v2 or later (GPLv2+)    |
-| python-dateutil         | 2.8.2     | Apache Software License; BSD License               |
-| python-louvain          | 0.16      | BSD License                                        |
-| pytz                    | 2022.1    | MIT License                                        |
-| ray                     | 1.6.0     | Apache 2.0                                         |
-| redis                   | 4.3.4     | MIT License                                        |
-| requests                | 2.28.1    | Apache Software License                            |
-| requests-oauthlib       | 1.3.1     | BSD License                                        |
-| rsa                     | 4.8       | Apache Software License                            |
-| scikit-learn            | 1.0.2     | new BSD                                            |
-| scipy                   | 1.5.4     | BSD License                                        |
-| six                     | 1.16.0    | MIT License                                        |
-| smart-open              | 6.0.0     | MIT License                                        |
-| snowballstemmer         | 2.2.0     | BSD License                                        |
-| stable-baselines3       | 1.4.0     | MIT                                                |
-| tabulate                | 0.8.9     | MIT License                                        |
-| tensorboard             | 2.9.1     | Apache Software License                            |
-| tensorboard-data-server | 0.6.1     | Apache Software License                            |
-| tensorboard-plugin-wit  | 1.8.1     | Apache 2.0                                         |
-| threadpoolctl           | 3.1.0     | BSD License                                        |
-| toml                    | 0.10.2    | MIT License                                        |
-| tomli                   | 2.0.1     | MIT License                                        |
-| torch                   | 1.12.0    | BSD License                                        |
-| tqdm                    | 4.64.0    | MIT License; Mozilla Public License 2.0 (MPL 2.0)  |
-| typing-extensions       | 3.7.4.3   | Python Software Foundation License                 |
-| urllib3                 | 1.26.10   | MIT License                                        |
-| wrapt                   | 1.14.1    | BSD License                                        |
-| yawningtitan            | 0.0.3     | MIT                                                |
-| zipp                    | 3.8.0     | MIT License                                        |
+| Name                          | Version    | License                                                                                          |
+|-------------------------------|------------|--------------------------------------------------------------------------------------------------|
+| Babel                         | 2.10.3     | BSD License                                                                                      |
+| Cython                        | 0.29.28    | Apache Software License                                                                          |
+| Jinja2                        | 3.1.2      | BSD License                                                                                      |
+| Levenshtein                   | 0.20.7     | GNU General Public License v2 or later (GPLv2+)                                                  |
+| Markdown                      | 3.4.1      | BSD License                                                                                      |
+| MarkupSafe                    | 2.1.1      | BSD License                                                                                      |
+| Pillow                        | 9.2.0      | Historical Permission Notice and Disclaimer (HPND)                                               |
+| PyGSP                         | 0.5.1      | BSD License                                                                                      |
+| PyWavelets                    | 1.4.1      | MIT License                                                                                      |
+| PyYAML                        | 5.4.1      | MIT License                                                                                      |
+| Pygments                      | 2.13.0     | BSD License                                                                                      |
+| Werkzeug                      | 2.2.2      | BSD License                                                                                      |
+| absl-py                       | 1.3.0      | Apache Software License                                                                          |
+| aiosignal                     | 1.2.0      | Apache Software License                                                                          |
+| alabaster                     | 0.7.12     | BSD License                                                                                      |
+| attrs                         | 22.1.0     | MIT License                                                                                      |
+| cachetools                    | 5.2.0      | MIT License                                                                                      |
+| certifi                       | 2022.9.24  | Mozilla Public License 2.0 (MPL 2.0)                                                             |
+| cfgv                          | 3.3.1      | MIT License                                                                                      |
+| charset-normalizer            | 2.1.1      | MIT License                                                                                      |
+| click                         | 8.0.4      | BSD License                                                                                      |
+| cloudpickle                   | 2.2.0      | BSD License                                                                                      |
+| colorama                      | 0.4.6      | BSD License                                                                                      |
+| commonmark                    | 0.9.1      | BSD License                                                                                      |
+| contourpy                     | 1.0.5      | BSD License                                                                                      |
+| coverage                      | 6.5.0      | Apache Software License                                                                          |
+| cycler                        | 0.11.0     | BSD License                                                                                      |
+| decorator                     | 4.4.2      | BSD License                                                                                      |
+| distlib                       | 0.3.6      | Python Software Foundation License                                                               |
+| dm-tree                       | 0.1.7      | Apache Software License                                                                          |
+| docutils                      | 0.17.1     | BSD License; GNU General Public License (GPL); Public Domain; Python Software Foundation License |
+| exceptiongroup                | 1.0.0rc9   | MIT License                                                                                      |
+| filelock                      | 3.8.0      | Public Domain                                                                                    |
+| flake8                        | 5.0.4      | MIT License                                                                                      |
+| fonttools                     | 4.38.0     | MIT License                                                                                      |
+| frozenlist                    | 1.3.1      | Apache Software License                                                                          |
+| gensim                        | 4.2.0      | LGPL-2.1-only                                                                                    |
+| google-auth                   | 2.13.0     | Apache Software License                                                                          |
+| google-auth-oauthlib          | 0.4.6      | Apache Software License                                                                          |
+| grpcio                        | 1.50.0     | Apache Software License                                                                          |
+| gym                           | 0.21.0     | UNKNOWN                                                                                          |
+| identify                      | 2.5.7      | MIT License                                                                                      |
+| idna                          | 3.4        | BSD License                                                                                      |
+| imageio                       | 2.9.0      | BSD License                                                                                      |
+| imagesize                     | 1.4.1      | MIT License                                                                                      |
+| importlib-metadata            | 4.13.0     | Apache Software License                                                                          |
+| iniconfig                     | 1.1.1      | MIT License                                                                                      |
+| joblib                        | 1.2.0      | BSD License                                                                                      |
+| jsonschema                    | 4.16.0     | MIT License                                                                                      |
+| karateclub                    | 1.3.0      | MIT License                                                                                      |
+| kiwisolver                    | 1.4.4      | BSD License                                                                                      |
+| lz4                           | 4.0.2      | BSD License                                                                                      |
+| matplotlib                    | 3.6.1      | Python Software Foundation License                                                               |
+| mccabe                        | 0.7.0      | MIT License                                                                                      |
+| msgpack                       | 1.0.4      | Apache Software License                                                                          |
+| networkx                      | 2.5.1      | BSD License                                                                                      |
+| nodeenv                       | 1.7.0      | BSD License                                                                                      |
+| numpy                         | 1.23.4     | BSD License                                                                                      |
+| oauthlib                      | 3.2.2      | BSD License                                                                                      |
+| packaging                     | 21.3       | Apache Software License; BSD License                                                             |
+| pandas                        | 1.3.5      | BSD License                                                                                      |
+| platformdirs                  | 2.5.2      | MIT License                                                                                      |
+| pluggy                        | 1.0.0      | MIT License                                                                                      |
+| pre-commit                    | 2.20.0     | MIT License                                                                                      |
+| protobuf                      | 3.19.6     | 3-Clause BSD License                                                                             |
+| pyasn1                        | 0.4.8      | BSD License                                                                                      |
+| pyasn1-modules                | 0.2.8      | BSD License                                                                                      |
+| pycodestyle                   | 2.9.1      | MIT License                                                                                      |
+| pyflakes                      | 2.5.0      | MIT License                                                                                      |
+| pyparsing                     | 3.0.9      | MIT License                                                                                      |
+| pyrsistent                    | 0.18.1     | MIT License                                                                                      |
+| pytest                        | 7.2.0      | MIT License                                                                                      |
+| pytest-cov                    | 4.0.0      | MIT License                                                                                      |
+| pytest-flake8                 | 1.1.1      | BSD License                                                                                      |
+| python-Levenshtein            | 0.20.7     | GNU General Public License v2 or later (GPLv2+)                                                  |
+| python-dateutil               | 2.8.2      | Apache Software License; BSD License                                                             |
+| python-louvain                | 0.16       | BSD License                                                                                      |
+| pytz                          | 2022.5     | MIT License                                                                                      |
+| rapidfuzz                     | 2.12.0     | MIT License                                                                                      |
+| ray                           | 3.0.0.dev0 | Apache 2.0                                                                                       |
+| requests                      | 2.28.1     | Apache Software License                                                                          |
+| requests-oauthlib             | 1.3.1      | BSD License                                                                                      |
+| rich                          | 12.6.0     | MIT License                                                                                      |
+| rsa                           | 4.9        | Apache Software License                                                                          |
+| scikit-image                  | 0.19.3     | BSD License                                                                                      |
+| scikit-learn                  | 1.1.2      | BSD License                                                                                      |
+| scipy                         | 1.9.2      | BSD License                                                                                      |
+| six                           | 1.16.0     | MIT License                                                                                      |
+| smart-open                    | 6.2.0      | MIT License                                                                                      |
+| snowballstemmer               | 2.2.0      | BSD License                                                                                      |
+| sphinx                        | 5.3.0      | BSD License                                                                                      |
+| sphinx-rtd-theme              | 1.0.0      | MIT License                                                                                      |
+| sphinxcontrib-applehelp       | 1.0.2      | BSD License                                                                                      |
+| sphinxcontrib-devhelp         | 1.0.2      | BSD License                                                                                      |
+| sphinxcontrib-htmlhelp        | 2.0.0      | BSD License                                                                                      |
+| sphinxcontrib-jsmath          | 1.0.1      | BSD License                                                                                      |
+| sphinxcontrib-qthelp          | 1.0.3      | BSD License                                                                                      |
+| sphinxcontrib-serializinghtml | 1.1.5      | BSD License                                                                                      |
+| stable-baselines3             | 1.6.2      | MIT                                                                                              |
+| tabulate                      | 0.8.9      | MIT License                                                                                      |
+| tensorboard                   | 2.10.1     | Apache Software License                                                                          |
+| tensorboard-data-server       | 0.6.1      | Apache Software License                                                                          |
+| tensorboard-plugin-wit        | 1.8.1      | Apache 2.0                                                                                       |
+| tensorboardX                  | 2.5.1      | MIT License                                                                                      |
+| threadpoolctl                 | 3.1.0      | BSD License                                                                                      |
+| tifffile                      | 2022.10.10 | BSD License                                                                                      |
+| toml                          | 0.10.2     | MIT License                                                                                      |
+| tomli                         | 2.0.1      | MIT License                                                                                      |
+| torch                         | 1.12.1     | BSD License                                                                                      |
+| tqdm                          | 4.64.1     | MIT License; Mozilla Public License 2.0 (MPL 2.0)                                                |
+| typer                         | 0.6.1      | MIT License                                                                                      |
+| typing-extensions             | 4.0.1      | Python Software Foundation License                                                               |
+| urllib3                       | 1.26.12    | MIT License                                                                                      |
+| virtualenv                    | 20.16.5    | MIT License                                                                                      |
+| yawningtitan                  | 0.1.0      | MIT                                                                                              |
+| zipp                          | 3.10.0     | MIT License                                                                                      |

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,89 @@
+import sys
+
 from setuptools import find_packages, setup
+
+
+def _ray_3_beta_rllib_py_platform_pip_install() -> str:
+    """
+    Maps the operating system and the Python version to the relevant .whl
+    file for Ray 3.0.0.dev0 beta version. Uses it to build a pip install
+    string for installing Ray 3.0.0.dev0 with the [rllib] extra.
+
+    whl source: https://docs.ray.io/en/master/ray-overview/installation.html
+
+    * A temporary measure to allow for use on Linux, Windows, and MacOS
+    while we wait for ray 3.0.0 release with full Windows support. *
+
+    Returns: A pip install string to install Ray 3.0.0.dev0 with the [rllib]
+        extra for the given OS and Python version.
+    Raises EnvironmentError: When either the operating system is not
+        supported or the Python version is not supported.
+    """
+    ray_wheels_root = "https://s3-us-west-2.amazonaws.com/ray-wheels/latest"
+    ray_3_py_platform_map = {
+        "linux": {  # Linux
+            (3, 8): "/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl",
+            (3, 9): "/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl",
+            (3, 10): "/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl",
+        },
+        "darmin": {  # MacOSX
+            (3, 8): "/ray-3.0.0.dev0-cp38-cp38-macosx_10_15_x86_64.whl",
+            (3, 9): "/ray-3.0.0.dev0-cp39-cp39-macosx_10_15_x86_64.whl",
+            (3, 10): "/ray-3.0.0.dev0-cp310-cp310-macosx_10_15_universal2.whl",
+        },
+        "win32": {  # Windows
+            (3, 8): "/ray-3.0.0.dev0-cp38-cp38-win_amd64.whl",
+            (3, 9): "/ray-3.0.0.dev0-cp39-cp39-win_amd64.whl",
+            (3, 10): "/ray-3.0.0.dev0-cp310-cp310-win_amd64.whl",
+        }
+    }
+    py_v = sys.version_info
+    py_v_major_minor = py_v[:2]
+    if sys.platform in ray_3_py_platform_map.keys():
+        if py_v_major_minor in ray_3_py_platform_map[sys.platform].keys():
+            ray_whl = ray_3_py_platform_map[sys.platform][py_v_major_minor]
+            whl_url = f"{ray_wheels_root}{ray_whl}"
+            return f"ray[rllib] @ {whl_url}"
+        else:
+            #  Python version not supported
+            raise EnvironmentError(
+                f"yawningtitan with ray on {sys.platform} is only supported "
+                f"by Python version 3.8.*, 3.9.*, and 3.10.*, currently using "
+                f"python version {py_v.major}.{py_v.minor}.{py_v.micro}"
+            )
+    else:
+        #  OS not supported
+        raise EnvironmentError(
+            f"yawningtitan with ray on {sys.platform} is only supported "
+            f"by Python version 3.8.*, 3.9.*, and 3.10.*, currently using "
+            f"{sys.platform}"
+        )
+
 
 setup(
     name="yawningtitan",
     maintainer="Defence Science and Technology Laboratory UK",
     maintainer_email="oss@dstl.gov.uk",
     url="https://github.com/dstl/YAWNING-TITAN",
-    description="An abstract, flexible and configurable cyber security simulation",
+    description="An abstract, flexible and configurable cyber security "
+                "simulation",
     python_requires=">=3.8",
     version="0.1.0",
     license="MIT",
     install_requires=[
         "gym==0.21.0",
-        "imageio == 2.9.0",
-        "matplotlib == 3.3.4",
-        "networkx == 2.5.1",
-        "numpy == 1.22.0",
-        "ray[rllib]",
-        "scipy == 1.5.4",
+        "imageio==2.9.0",
+        "matplotlib==3.6.1",
+        "networkx==2.5.1",
+        "numpy==1.23.4",
+        _ray_3_beta_rllib_py_platform_pip_install(),
+        "scipy==1.9.2",
         "stable_baselines3",
-        "tabulate == 0.8.9",
+        "tabulate==0.8.9",
         "karateclub",
-        "pandas == 1.2.3",
-        "pyyaml == 5.4.1",
-        "typing-extensions == 3.7.4.3",
+        "pandas==1.3.5",
+        "pyyaml==5.4.1",
+        "typing-extensions==4.0.1",
         "torch",
         "tensorboard",
         "dm-tree",

--- a/yawning_titan/envs/generic/core/action_loops.py
+++ b/yawning_titan/envs/generic/core/action_loops.py
@@ -4,6 +4,7 @@ The ``ActionLoop`` class helps reduce boilerplate code when evaluating an agent 
 Serves a similar function to library helpers such as Stable Baselines 3 ``evaluate_policy()".
 """
 import os
+import pathlib
 import sys
 from pathlib import Path
 
@@ -31,9 +32,9 @@ class ActionLoop:
 
     def gif_action_loop(self):
         """Run the agent in evaluation and create a gif from episodes."""
-        str_path = sys.path[0]
+        str_path = pathlib.Path(sys.path[0]).as_posix()
         list_path = str_path.split("/")
-        index = len(list_path) - 1 - list_path[::-1].index("yawning-titan")
+        index = len(list_path) - 1 - list_path[::-1].index("YAWNING-TITAN")
         new_list = list_path[: index + 1]
         # gets the default settings file path
         image_path_str = "/".join(new_list) + "/yawning_titan/envs/generic/core/images"

--- a/yawning_titan/envs/generic/core/network_interface.py
+++ b/yawning_titan/envs/generic/core/network_interface.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import json
 import math
+import pathlib
 import random
 import sys
 from collections import Counter, defaultdict
@@ -16,7 +17,8 @@ import yaml
 from numpy.random import choice
 from yaml.loader import SafeLoader
 
-from yawning_titan.envs.generic.helpers.environment_input_validation import check_input
+from yawning_titan.envs.generic.helpers.environment_input_validation import \
+    check_input
 from yawning_titan.envs.generic.helpers.node_attribute_gen import (
     generate_vulnerabilities,
     generate_vulnerability,
@@ -50,9 +52,9 @@ class NetworkInterface:
         # If the user has not input a settings file then find the default one
         if settings_path is None:
             # gets the current path and backtracks to the main "yawning-titan" folder
-            str_path = sys.path[0]
+            str_path = pathlib.Path(sys.path[0]).as_posix()
             list_path = str_path.split("/")
-            index = len(list_path) - 1 - list_path[::-1].index("yawning-titan")
+            index = len(list_path) - 1 - list_path[::-1].index("YAWNING-TITAN")
             new_list = list_path[: index + 1]
             # gets the default settings file path
             settings_path = "/".join(new_list) + "/game_modes/default_game_mode.yaml"
@@ -65,9 +67,9 @@ class NetworkInterface:
             print("[Warning] Cannot find configuration file, using default instead")
 
             # gets the current path and backtracks to the main "yawning-titan" folder
-            str_path = sys.path[0]
+            str_path = pathlib.Path(sys.path[0]).as_posix()
             list_path = str_path.split("/")
-            index = len(list_path) - 1 - list_path[::-1].index("yawning-titan")
+            index = len(list_path) - 1 - list_path[::-1].index("YAWNING-TITAN")
             new_list = list_path[: index + 1]
             # gets the default settings file path
             settings_path = "/".join(new_list) + "/game_modes/default_game_mode.yaml"


### PR DESCRIPTION
### Includes
- Added dynamic generation of ray[rllib] install string so that the correct ray.3.0.0.dev0 .whl file is used for the given OS and Python version. 
- Fixed issue with path splitting in Windows and updated root-dir name to uppercase to match GitHub repo name. 
- Updated a bunch of dependencies and regenerated the dep_licenses.md file.

### Tests
Install test carried out in a virtual environment on Windows, Linux, and MacOS using `pip install -e .[dev]`. 53 of 58 unit tests are passing; the 5 that are failing are due to randomness in the tests causing the assertions to fail. Although the commit shows as passing in TeamCity, ignore this as it's not properly configured yet.