### PR TITLE
AIDT-112 - Enable testing of Jupyter Notebooks

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -41,6 +41,3 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
-      - name: Test Jupyter Notebooks with pytest and nbmake
-        run: |
-          pytest --nbmake "yawning_titan/notebooks/_package_data/sb3/"

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -41,3 +41,6 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
+      - name: Test Jupyter Notebooks with pytest and nbmake
+        run: |
+          pytest --nbmake "yawning_titan/notebooks/_package_data/sb3/"

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
         "pandas==1.3.5",
         "platformdirs==2.5.2",
         "pyyaml==5.4.1",
-        "typing-extensions==4.0.1",
+        "typing-extensions==4.4.0",
         "torch==1.12.1 ",
         "tensorboard==2.10.1 ",
         "dm-tree==0.1.7",
@@ -162,6 +162,7 @@ setup(
             "sphinx_rtd_theme",
             "sphinx",
             "pre-commit",
+            "nbmake==1.3.4",
         ],
         "tensorflow": ["tensorflow"],  # TODO: Determine version and lock it in
         "jupyter": ["jupyter"],


### PR DESCRIPTION
Added nbmake==1.3.4 to setup.py and fixed dependency issue with nbmake and typing-extensions as it needs typing-extensions==4.4.0.

I did have a test in the GitHub actions pipeline but it doesn't work in GitHub for some reason. Will need to run Jupyter tests locally for now.